### PR TITLE
Daniil-Harry: feature branch

### DIFF
--- a/src/main/java/com/createfuture/training/taskmanager/controller/TaskRestController.java
+++ b/src/main/java/com/createfuture/training/taskmanager/controller/TaskRestController.java
@@ -2,6 +2,12 @@ package com.createfuture.training.taskmanager.controller;
 
 import com.createfuture.training.taskmanager.model.Task;
 import com.createfuture.training.taskmanager.service.TaskService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +25,17 @@ public class TaskRestController {
         this.taskService = taskService;
     }
 
+    /**
+     * Get all tasks
+     *
+     * @return list of all tasks
+     */
+    @Operation(summary = "Get all tasks")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successful operation", 
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = Task.class)))),
+        @ApiResponse(responseCode = "400", description = "Not Found", content = @Content)
+    })
     // GET /api/tasks
     @GetMapping
     public ResponseEntity<List<Task>> getAllTasks() {
@@ -59,5 +76,23 @@ public class TaskRestController {
     public ResponseEntity<Task> updateTask(@PathVariable Long id, @RequestBody Task task) {
         Task updatedTask = taskService.updateTask(id, task.getTitle());
         return updatedTask != null ? ResponseEntity.ok(updatedTask) : ResponseEntity.notFound().build();
+    }
+
+    /**
+     * Search tasks by title (partial match)
+     *
+     * @param title the partial title to search for
+     * @return list of matching tasks
+     */
+    @Operation(summary = "Search tasks by title (partial match)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Tasks found",
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = Task.class)))),
+        @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content)
+    })
+    @GetMapping("/search")
+    public ResponseEntity<List<Task>> searchTasksByTitle(@RequestParam String title) {
+        List<Task> tasks = taskService.searchTasksByTitle(title);
+        return ResponseEntity.ok(tasks);
     }
 }

--- a/src/main/java/com/createfuture/training/taskmanager/repository/TaskRepository.java
+++ b/src/main/java/com/createfuture/training/taskmanager/repository/TaskRepository.java
@@ -23,8 +23,8 @@ public class TaskRepository {
     );
 
     public Task addTask(String title) {
-        String sql = "INSERT INTO tasks (done, title) VALUES (false, '" + title + "')";
-        jdbcTemplate.execute(sql);
+        String sql = "INSERT INTO tasks (done, title) VALUES (?, ?)";
+        jdbcTemplate.update(sql, false, title);
         return getLastInsertedTaskByTitle(title);
     }
 

--- a/src/main/java/com/createfuture/training/taskmanager/repository/TaskRepository.java
+++ b/src/main/java/com/createfuture/training/taskmanager/repository/TaskRepository.java
@@ -69,4 +69,10 @@ public class TaskRepository {
         String sql = "UPDATE tasks SET title = ?, done = ? WHERE id = ?";
         return jdbcTemplate.update(sql, task.getTitle(), task.isDone(), task.getId());
     }
+
+    public List<Task> findByTitleContaining(String titlePart) {
+        String sql = "SELECT * FROM tasks WHERE LOWER(title) LIKE ?";
+        String pattern = "%" + titlePart.toLowerCase() + "%";
+        return jdbcTemplate.query(sql, taskMapper, pattern);
+    }
 }

--- a/src/main/java/com/createfuture/training/taskmanager/service/TaskService.java
+++ b/src/main/java/com/createfuture/training/taskmanager/service/TaskService.java
@@ -50,4 +50,8 @@ public class TaskService {
         }
         return task;
     }
+
+    public List<Task> searchTasksByTitle(String titlePart) {
+        return taskRepository.findByTitleContaining(titlePart);
+    }
 }

--- a/src/test/java/com/createfuture/training/taskmanager/controller/TaskRestControllerTest.java
+++ b/src/test/java/com/createfuture/training/taskmanager/controller/TaskRestControllerTest.java
@@ -105,4 +105,19 @@ class TaskRestControllerTest {
         mockMvc.perform(patch("/api/tasks/1/done"))
                 .andExpect(status().isNoContent());
     }
+
+    @Test
+    @DisplayName("GET /api/tasks/search?title=foo should return tasks matching partial title")
+    void shouldReturnTasksMatchingPartialTitle() throws Exception {
+        List<Task> mockTasks = Arrays.asList(
+            new Task(1L, "fooBar", false),
+            new Task(2L, "barFoo", false)
+        );
+        when(taskService.searchTasksByTitle("foo")).thenReturn(mockTasks);
+
+        mockMvc.perform(get("/api/tasks/search").param("title", "foo"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title", containsStringIgnoringCase("foo")))
+                .andExpect(jsonPath("$[1].title", containsStringIgnoringCase("foo")));
+    }
 }


### PR DESCRIPTION
This pull request enhances the `TaskManager` application by introducing a new feature for searching tasks by partial title, improving SQL query security, and adding comprehensive API documentation. Key changes include the addition of a search endpoint, parameterized SQL queries to prevent SQL injection, and unit tests for the new functionality.

### New Feature: Search Tasks by Partial Title
* [`src/main/java/com/createfuture/training/taskmanager/controller/TaskRestController.java`](diffhunk://#diff-8552ac7c94e29e19a558a9b2f14f7c14855d05bf9580461024759be383436e3cR80-R97): Added a new endpoint `/api/tasks/search` to allow users to search for tasks by partial title. Annotated the endpoint with OpenAPI documentation for better API visibility.
* [`src/main/java/com/createfuture/training/taskmanager/repository/TaskRepository.java`](diffhunk://#diff-bbfbdce3fe275251c9580fbc0ce651c64d3c14f13d58821fc46e64355295517aR72-R77): Added a new method `findByTitleContaining` to query tasks with titles matching a partial string using parameterized SQL.
* [`src/main/java/com/createfuture/training/taskmanager/service/TaskService.java`](diffhunk://#diff-1f4720db29c3845b3b12cbcb6ac23d3620eb14b87779bf4d2536670f9f42c43dR53-R56): Added a corresponding service method `searchTasksByTitle` to delegate the search functionality to the repository layer.

### SQL Query Security Improvements
* [`src/main/java/com/createfuture/training/taskmanager/repository/TaskRepository.java`](diffhunk://#diff-bbfbdce3fe275251c9580fbc0ce651c64d3c14f13d58821fc46e64355295517aL26-R27): Refactored the `addTask` method to use parameterized SQL queries, replacing string concatenation to prevent SQL injection vulnerabilities.

### Unit Tests for Search Functionality
* [`src/test/java/com/createfuture/training/taskmanager/controller/TaskRestControllerTest.java`](diffhunk://#diff-4a77e52923a85dedd940aca8b14b6941faf5352eb9c205648bd0b84c6ed45db8R108-R122): Added a new test case `shouldReturnTasksMatchingPartialTitle` to validate the `/api/tasks/search` endpoint and ensure it returns tasks matching the partial title.

### API Documentation Enhancements
* [`src/main/java/com/createfuture/training/taskmanager/controller/TaskRestController.java`](diffhunk://#diff-8552ac7c94e29e19a558a9b2f14f7c14855d05bf9580461024759be383436e3cR28-R38): Added OpenAPI annotations (`@Operation`, `@ApiResponses`) for the `getAllTasks` and `searchTasksByTitle` endpoints to provide detailed API documentation. [[1]](diffhunk://#diff-8552ac7c94e29e19a558a9b2f14f7c14855d05bf9580461024759be383436e3cR28-R38) [[2]](diffhunk://#diff-8552ac7c94e29e19a558a9b2f14f7c14855d05bf9580461024759be383436e3cR80-R97)